### PR TITLE
feat: extract skill manifest from opencode recipe into assets/configs/ai/skills.json

### DIFF
--- a/assets/configs/ai/skills.json
+++ b/assets/configs/ai/skills.json
@@ -1,18 +1,15 @@
 {
   "skills": [
     {
-      "repo": "./assets/configs/ai/skills",
-      "agent": "universal"
+      "repo": "./assets/configs/ai/skills"
     },
     {
       "repo": "anthropics/skills",
-      "skills": ["skill-creator"],
-      "agent": "universal"
+      "skills": ["skill-creator"]
     },
     {
       "repo": "JuliusBrussee/caveman",
-      "skills": ["caveman", "caveman-compress", "caveman-commit", "caveman-help", "caveman-review"],
-      "agent": "universal"
+      "skills": ["caveman", "caveman-compress", "caveman-commit", "caveman-help", "caveman-review"]
     }
   ]
 }

--- a/assets/configs/ai/skills.json
+++ b/assets/configs/ai/skills.json
@@ -1,9 +1,9 @@
 {
-  "local": {
-    "source": "ai/skills",
-    "target": "~/.agents/skills"
-  },
-  "remote": [
+  "skills": [
+    {
+      "repo": "./assets/configs/ai/skills",
+      "agent": "universal"
+    },
     {
       "repo": "anthropics/skills",
       "skills": ["skill-creator"],

--- a/assets/configs/ai/skills.json
+++ b/assets/configs/ai/skills.json
@@ -1,0 +1,16 @@
+{
+  "local": {
+    "source": "ai/skills",
+    "target": "~/.agents/skills"
+  },
+  "remote": [
+    {
+      "repo": "anthropics/skills",
+      "skills": ["skill-creator"]
+    },
+    {
+      "repo": "JuliusBrussee/caveman",
+      "skills": ["caveman", "caveman-compress", "caveman-commit", "caveman-help", "caveman-review"]
+    }
+  ]
+}

--- a/assets/configs/ai/skills.json
+++ b/assets/configs/ai/skills.json
@@ -6,11 +6,13 @@
   "remote": [
     {
       "repo": "anthropics/skills",
-      "skills": ["skill-creator"]
+      "skills": ["skill-creator"],
+      "agent": "universal"
     },
     {
       "repo": "JuliusBrussee/caveman",
-      "skills": ["caveman", "caveman-compress", "caveman-commit", "caveman-help", "caveman-review"]
+      "skills": ["caveman", "caveman-compress", "caveman-commit", "caveman-help", "caveman-review"],
+      "agent": "universal"
     }
   ]
 }

--- a/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
+++ b/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
@@ -1,0 +1,74 @@
+pkg.recipe.define ai-skills \
+    managers="npm" \
+    npm="skills@latest"
+
+pkg.recipe.ai-skills.configure() {
+    registry.is_enabled pkg ai-skills pkg.recipe || return 0
+
+    tui.task "Configuring ai-skills..."
+    tui.indent.push
+    {
+        (( $+commands[jq] )) || { tui.warn "jq command not found, skipping"; return 0; }
+        (( $+commands[npx] )) || { tui.warn "npx command not found, skipping"; return 0; }
+
+        local skills_file="${DOTFILES_DIR:-${HOME}/.dotfiles}/assets/configs/ai/skills.json"
+
+        if [[ ! -f "$skills_file" ]]; then
+            tui.warn "Skills manifest not found: $skills_file"
+            return 0
+        fi
+
+        local source_dir target_dir
+        source_dir=$(jq -r '.local.source // empty' "$skills_file")
+        target_dir=$(jq -r '.local.target // empty' "$skills_file")
+
+        if [[ -n "$source_dir" && -n "$target_dir" ]]; then
+            # eval to expand ~ in target
+            target_dir=$(eval echo "$target_dir")
+            tui.step "Linking skills directory"
+            config.symlink --force --contents "$source_dir" "$target_dir"
+        else
+            tui.step "Linking skills directory"
+            config.symlink --force --contents "ai/skills" "${HOME}/.agents/skills"
+        fi
+
+        local repo names name out
+        local -a name_args
+
+        # Read remote skills from JSON
+        local remote_items
+        remote_items=$(jq -c '.remote[]?' "$skills_file")
+
+        if [[ -n "$remote_items" ]]; then
+            echo "$remote_items" | while IFS= read -r item; do
+                repo=$(echo "$item" | jq -r '.repo // empty')
+                [[ -z "$repo" ]] && continue
+
+                name_args=()
+                local skills_str
+                skills_str=$(echo "$item" | jq -r 'if .skills then (.skills | join(",")) else empty end')
+
+                if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
+                    name_args=(--skill "*")
+                    tui.step "Skills: * (${repo})"
+                else
+                    # Iterate through JSON array
+                    for name in $(echo "$item" | jq -r '.skills[]?'); do
+                        name_args+=(--skill "$name")
+                    done
+                    tui.step "Skills: ${skills_str} (${repo})"
+                fi
+
+                # Note: keeping --agent universal so it works with all agents
+                if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent universal -y < /dev/null 2>&1); then
+                    tui.error "Failed to install ${repo}"
+                    echo "$out" | grep -v "█"
+                fi
+            done
+        fi
+
+        tui.success "Configuration complete"
+    } always {
+        tui.indent.pop
+    }
+}

--- a/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
+++ b/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
@@ -24,28 +24,29 @@ pkg.recipe.ai-skills.configure() {
         target_dir=$(eval echo "$(jq -r '.local.target // "~/.agents/skills"' "$skills_file")")
         config.symlink --force --contents "$source_dir" "$target_dir"
 
-        local repo skills_str out
+        local repo skills_str agent out
         local -a name_args
 
-        while IFS=$'\t' read -r repo skills_str; do
+        while IFS=$'\t' read -r repo skills_str agent; do
             [[ -z "$repo" ]] && continue
+            [[ -z "$agent" ]] && agent="universal"
 
             name_args=()
             if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
                 name_args=(--skill "*")
-                tui.step "Skills: * (${repo})"
+                tui.step "Skills: * (${repo}) for ${agent}"
             else
                 for name in ${(s:,:)skills_str}; do
                     name_args+=(--skill "$name")
                 done
-                tui.step "Skills: ${skills_str} (${repo})"
+                tui.step "Skills: ${skills_str} (${repo}) for ${agent}"
             fi
 
-            if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent universal -y < /dev/null 2>&1); then
+            if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent "$agent" -y < /dev/null 2>&1); then
                 tui.error "Failed to install ${repo}"
                 echo "$out" | grep -v "█"
             fi
-        done < <(jq -r '.remote[]? | "\(.repo)\t\(.skills | join(",") // "")"' "$skills_file")
+        done < <(jq -r '.remote[]? | "\(.repo)\t\(.skills | join(",") // "")\t\(.agent // "universal")"' "$skills_file")
 
         tui.success "Configuration complete"
     } always {

--- a/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
+++ b/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
@@ -4,52 +4,5 @@ pkg.recipe.define ai-skills \
 
 pkg.recipe.ai-skills.configure() {
     registry.is_enabled pkg ai-skills pkg.recipe || return 0
-
-    tui.task "Configuring ai-skills..."
-    tui.indent.push
-    {
-        (( $+commands[jq] )) || { tui.warn "jq command not found, skipping"; return 0; }
-        (( $+commands[npx] )) || { tui.warn "npx command not found, skipping"; return 0; }
-
-        local skills_file="${DOTFILES_DIR:-${HOME}/.dotfiles}/assets/configs/ai/skills.json"
-
-        if [[ ! -f "$skills_file" ]]; then
-            tui.warn "Skills manifest not found: $skills_file"
-            return 0
-        fi
-
-        tui.step "Linking skills directory"
-        local source_dir target_dir
-        source_dir=$(jq -r '.local.source // "ai/skills"' "$skills_file")
-        target_dir=$(eval echo "$(jq -r '.local.target // "~/.agents/skills"' "$skills_file")")
-        config.symlink --force --contents "$source_dir" "$target_dir"
-
-        local repo skills_str agent out
-        local -a name_args
-
-        while IFS=$'\t' read -r repo skills_str agent; do
-            [[ -z "$repo" ]] && continue
-            [[ -z "$agent" ]] && agent="universal"
-
-            name_args=()
-            if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
-                name_args=(--skill "*")
-                tui.step "Skills: * (${repo}) for ${agent}"
-            else
-                for name in ${(s:,:)skills_str}; do
-                    name_args+=(--skill "$name")
-                done
-                tui.step "Skills: ${skills_str} (${repo}) for ${agent}"
-            fi
-
-            if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent "$agent" -y < /dev/null 2>&1); then
-                tui.error "Failed to install ${repo}"
-                echo "$out" | grep -v "█"
-            fi
-        done < <(jq -r '.remote[]? | "\(.repo)\t\(.skills | join(",") // "")\t\(.agent // "universal")"' "$skills_file")
-
-        tui.success "Configuration complete"
-    } always {
-        tui.indent.pop
-    }
+    ai.skills.install "universal"
 }

--- a/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
+++ b/src/zsh/apps/pkg/recipes/ai/ai-skills.zsh
@@ -18,54 +18,34 @@ pkg.recipe.ai-skills.configure() {
             return 0
         fi
 
+        tui.step "Linking skills directory"
         local source_dir target_dir
-        source_dir=$(jq -r '.local.source // empty' "$skills_file")
-        target_dir=$(jq -r '.local.target // empty' "$skills_file")
+        source_dir=$(jq -r '.local.source // "ai/skills"' "$skills_file")
+        target_dir=$(eval echo "$(jq -r '.local.target // "~/.agents/skills"' "$skills_file")")
+        config.symlink --force --contents "$source_dir" "$target_dir"
 
-        if [[ -n "$source_dir" && -n "$target_dir" ]]; then
-            # eval to expand ~ in target
-            target_dir=$(eval echo "$target_dir")
-            tui.step "Linking skills directory"
-            config.symlink --force --contents "$source_dir" "$target_dir"
-        else
-            tui.step "Linking skills directory"
-            config.symlink --force --contents "ai/skills" "${HOME}/.agents/skills"
-        fi
-
-        local repo names name out
+        local repo skills_str out
         local -a name_args
 
-        # Read remote skills from JSON
-        local remote_items
-        remote_items=$(jq -c '.remote[]?' "$skills_file")
+        while IFS=$'\t' read -r repo skills_str; do
+            [[ -z "$repo" ]] && continue
 
-        if [[ -n "$remote_items" ]]; then
-            echo "$remote_items" | while IFS= read -r item; do
-                repo=$(echo "$item" | jq -r '.repo // empty')
-                [[ -z "$repo" ]] && continue
+            name_args=()
+            if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
+                name_args=(--skill "*")
+                tui.step "Skills: * (${repo})"
+            else
+                for name in ${(s:,:)skills_str}; do
+                    name_args+=(--skill "$name")
+                done
+                tui.step "Skills: ${skills_str} (${repo})"
+            fi
 
-                name_args=()
-                local skills_str
-                skills_str=$(echo "$item" | jq -r 'if .skills then (.skills | join(",")) else empty end')
-
-                if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
-                    name_args=(--skill "*")
-                    tui.step "Skills: * (${repo})"
-                else
-                    # Iterate through JSON array
-                    for name in $(echo "$item" | jq -r '.skills[]?'); do
-                        name_args+=(--skill "$name")
-                    done
-                    tui.step "Skills: ${skills_str} (${repo})"
-                fi
-
-                # Note: keeping --agent universal so it works with all agents
-                if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent universal -y < /dev/null 2>&1); then
-                    tui.error "Failed to install ${repo}"
-                    echo "$out" | grep -v "█"
-                fi
-            done
-        fi
+            if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent universal -y < /dev/null 2>&1); then
+                tui.error "Failed to install ${repo}"
+                echo "$out" | grep -v "█"
+            fi
+        done < <(jq -r '.remote[]? | "\(.repo)\t\(.skills | join(",") // "")"' "$skills_file")
 
         tui.success "Configuration complete"
     } always {

--- a/src/zsh/apps/pkg/recipes/ai/opencode.zsh
+++ b/src/zsh/apps/pkg/recipes/ai/opencode.zsh
@@ -20,78 +20,10 @@ pkg.recipe.opencode.configure() {
         pkg.recipe.opencode.configure.providers "$target"
         pkg.recipe.opencode.configure.mcps "$target"
 
-        local skills_file="${DOTFILES_DIR:-${HOME}/.dotfiles}/assets/configs/ai/skills.json"
-
-        # Check if skills manifest exists
-        if [[ -f "$skills_file" ]]; then
-            local source_dir target_dir
-            source_dir=$(jq -r '.local.source // empty' "$skills_file")
-            target_dir=$(jq -r '.local.target // empty' "$skills_file")
-
-            if [[ -n "$source_dir" && -n "$target_dir" ]]; then
-                # eval to expand ~ in target
-                target_dir=$(eval echo "$target_dir")
-                tui.step "Linking skills directory"
-                config.symlink --force --contents "$source_dir" "$target_dir"
-            else
-                tui.step "Linking skills directory"
-                config.symlink --force --contents "ai/skills" "${HOME}/.agents/skills"
-            fi
-        else
-            tui.step "Linking skills directory"
-            config.symlink --force --contents "ai/skills" "${HOME}/.agents/skills"
-        fi
-
-        pkg.recipe.opencode.configure.skills "$skills_file"
-
         tui.success "Configuration complete"
     } always {
         tui.indent.pop
     }
-}
-
-pkg.recipe.opencode.configure.skills() {
-    local skills_file="${1:-}"
-    if [[ ! -f "$skills_file" ]]; then
-        tui.warn "Skills manifest not found: $skills_file"
-        return 0
-    fi
-
-    local repo names name out
-    local -a name_args
-
-    # Read remote skills from JSON
-    local remote_items
-    remote_items=$(jq -c '.remote[]?' "$skills_file")
-
-    if [[ -z "$remote_items" ]]; then
-        return 0
-    fi
-
-    echo "$remote_items" | while IFS= read -r item; do
-        repo=$(echo "$item" | jq -r '.repo // empty')
-        [[ -z "$repo" ]] && continue
-
-        name_args=()
-        local skills_str
-        skills_str=$(echo "$item" | jq -r 'if .skills then (.skills | join(",")) else empty end')
-
-        if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
-            name_args=(--skill "*")
-            tui.step "Skills: * (${repo})"
-        else
-            # Iterate through JSON array
-            for name in $(echo "$item" | jq -r '.skills[]?'); do
-                name_args+=(--skill "$name")
-            done
-            tui.step "Skills: ${skills_str} (${repo})"
-        fi
-
-        if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent universal -y < /dev/null 2>&1); then
-            tui.error "Failed to install ${repo}"
-            echo "$out" | grep -v "█"
-        fi
-    done
 }
 
 

--- a/src/zsh/apps/pkg/recipes/ai/opencode.zsh
+++ b/src/zsh/apps/pkg/recipes/ai/opencode.zsh
@@ -20,9 +20,29 @@ pkg.recipe.opencode.configure() {
         pkg.recipe.opencode.configure.providers "$target"
         pkg.recipe.opencode.configure.mcps "$target"
 
-        tui.step "Linking skills directory"
-        config.symlink --force --contents "ai/skills" "${HOME}/.agents/skills"
-        pkg.recipe.opencode.configure.skills
+        local skills_file="${DOTFILES_DIR:-${HOME}/.dotfiles}/assets/configs/ai/skills.json"
+
+        # Check if skills manifest exists
+        if [[ -f "$skills_file" ]]; then
+            local source_dir target_dir
+            source_dir=$(jq -r '.local.source // empty' "$skills_file")
+            target_dir=$(jq -r '.local.target // empty' "$skills_file")
+
+            if [[ -n "$source_dir" && -n "$target_dir" ]]; then
+                # eval to expand ~ in target
+                target_dir=$(eval echo "$target_dir")
+                tui.step "Linking skills directory"
+                config.symlink --force --contents "$source_dir" "$target_dir"
+            else
+                tui.step "Linking skills directory"
+                config.symlink --force --contents "ai/skills" "${HOME}/.agents/skills"
+            fi
+        else
+            tui.step "Linking skills directory"
+            config.symlink --force --contents "ai/skills" "${HOME}/.agents/skills"
+        fi
+
+        pkg.recipe.opencode.configure.skills "$skills_file"
 
         tui.success "Configuration complete"
     } always {
@@ -31,31 +51,44 @@ pkg.recipe.opencode.configure() {
 }
 
 pkg.recipe.opencode.configure.skills() {
-    local -a skills=(
-        "anthropics/skills:skill-creator"
-        "JuliusBrussee/caveman:caveman,caveman-compress,caveman-commit,caveman-help,caveman-review"
-    )
+    local skills_file="${1:-}"
+    if [[ ! -f "$skills_file" ]]; then
+        tui.warn "Skills manifest not found: $skills_file"
+        return 0
+    fi
 
-    local item repo names name out
+    local repo names name out
     local -a name_args
-    for item in "${skills[@]}"; do
-        repo="${item%%:*}"
-        names="${item#*:}"
+
+    # Read remote skills from JSON
+    local remote_items
+    remote_items=$(jq -c '.remote[]?' "$skills_file")
+
+    if [[ -z "$remote_items" ]]; then
+        return 0
+    fi
+
+    echo "$remote_items" | while IFS= read -r item; do
+        repo=$(echo "$item" | jq -r '.repo // empty')
+        [[ -z "$repo" ]] && continue
 
         name_args=()
-        if [[ "$repo" == "$names" || "$names" == "*" ]]; then
+        local skills_str
+        skills_str=$(echo "$item" | jq -r 'if .skills then (.skills | join(",")) else empty end')
+
+        if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
             name_args=(--skill "*")
             tui.step "Skills: * (${repo})"
         else
-            # Split comma-separated names into multiple --skill flags
-            for name in ${(s:,:)names}; do
+            # Iterate through JSON array
+            for name in $(echo "$item" | jq -r '.skills[]?'); do
                 name_args+=(--skill "$name")
             done
-            tui.step "Skills: ${names} (${repo})"
+            tui.step "Skills: ${skills_str} (${repo})"
         fi
 
         if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent universal -y < /dev/null 2>&1); then
-            tui.error "Failed to install ${item}"
+            tui.error "Failed to install ${repo}"
             echo "$out" | grep -v "█"
         fi
     done

--- a/src/zsh/functions/ai.zsh
+++ b/src/zsh/functions/ai.zsh
@@ -333,7 +333,7 @@ ai.skills.install() {
                 tui.error "Failed to install ${repo}"
                 echo "$out" | grep -v "█"
             fi
-        done < <(jq -r '.skills[]? | "\(.repo)\t\(.skills | join(",") // "")"' "$skills_file")
+        done < <(jq -r '.skills[]? | "\(.repo)\t\((.skills // []) | join(","))"' "$skills_file")
 
         tui.success "Configuration complete for $agent"
     } always {

--- a/src/zsh/functions/ai.zsh
+++ b/src/zsh/functions/ai.zsh
@@ -293,7 +293,7 @@ EOF
 # --- Skills ---
 ai.skills.install() {
     local agent="${1:-universal}"
-    local skills_file="${DOTFILES_DIR:-${HOME}/.dotfiles}/assets/configs/ai/skills.json"
+    local skills_file="${DOTFILES:-${HOME}/.dotfiles}/assets/configs/ai/skills.json"
 
     if [[ ! -f "$skills_file" ]]; then
         tui.warn "Skills manifest not found: $skills_file"

--- a/src/zsh/functions/ai.zsh
+++ b/src/zsh/functions/ai.zsh
@@ -289,3 +289,60 @@ ai.chat() {
 EOF
 }
 
+
+# --- Skills ---
+ai.skills.install() {
+    local agent="${1:-universal}"
+    local skills_file="${DOTFILES_DIR:-${HOME}/.dotfiles}/assets/configs/ai/skills.json"
+
+    if [[ ! -f "$skills_file" ]]; then
+        tui.warn "Skills manifest not found: $skills_file"
+        return 0
+    fi
+
+    tui.task "Configuring ai-skills for agent: $agent"
+    tui.indent.push
+    {
+        (( $+commands[jq] )) || { tui.warn "jq command not found, skipping"; return 0; }
+        (( $+commands[npx] )) || { tui.warn "npx command not found, skipping"; return 0; }
+
+        tui.step "Linking skills directory"
+        local source_dir target_dir
+        source_dir=$(jq -r '.local.source // "ai/skills"' "$skills_file")
+        target_dir=$(eval echo "$(jq -r '.local.target // "~/.agents/skills"' "$skills_file")")
+        config.symlink --force --contents "$source_dir" "$target_dir"
+
+        local repo skills_str agent_config out
+        local -a name_args
+
+        while IFS=$'\t' read -r repo skills_str agent_config; do
+            [[ -z "$repo" ]] && continue
+
+            # Use specific agent passed, or fallback to the one defined in config, or universal
+            local current_agent="$agent"
+            if [[ "$current_agent" == "universal" && -n "$agent_config" && "$agent_config" != "null" ]]; then
+                 current_agent="$agent_config"
+            fi
+
+            name_args=()
+            if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
+                name_args=(--skill "*")
+                tui.step "Skills: * (${repo}) for ${current_agent}"
+            else
+                for name in ${(s:,:)skills_str}; do
+                    name_args+=(--skill "$name")
+                done
+                tui.step "Skills: ${skills_str} (${repo}) for ${current_agent}"
+            fi
+
+            if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent "$current_agent" -y < /dev/null 2>&1); then
+                tui.error "Failed to install ${repo}"
+                echo "$out" | grep -v "█"
+            fi
+        done < <(jq -r '.remote[]? | "\(.repo)\t\(.skills | join(",") // "")\t\(.agent // "")"' "$skills_file")
+
+        tui.success "Configuration complete for $agent"
+    } always {
+        tui.indent.pop
+    }
+}

--- a/src/zsh/functions/ai.zsh
+++ b/src/zsh/functions/ai.zsh
@@ -306,17 +306,11 @@ ai.skills.install() {
         (( $+commands[jq] )) || { tui.warn "jq command not found, skipping"; return 0; }
         (( $+commands[npx] )) || { tui.warn "npx command not found, skipping"; return 0; }
 
-        local repo skills_str agent_config out full_repo
+        local repo skills_str out full_repo
         local -a name_args
 
-        while IFS=$'\t' read -r repo skills_str agent_config; do
+        while IFS=$'\t' read -r repo skills_str; do
             [[ -z "$repo" ]] && continue
-
-            # Use specific agent passed, or fallback to the one defined in config, or universal
-            local current_agent="$agent"
-            if [[ "$current_agent" == "universal" && -n "$agent_config" && "$agent_config" != "null" ]]; then
-                 current_agent="$agent_config"
-            fi
 
             # Handle relative local directories by prepending DOTFILES_DIR
             full_repo="$repo"
@@ -326,19 +320,19 @@ ai.skills.install() {
 
             name_args=()
             if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
-                tui.step "Skills: * (${repo}) for ${current_agent}"
+                tui.step "Skills: * (${repo}) for ${agent}"
             else
                 for name in ${(s:,:)skills_str}; do
                     name_args+=(--skill "$name")
                 done
-                tui.step "Skills: ${skills_str} (${repo}) for ${current_agent}"
+                tui.step "Skills: ${skills_str} (${repo}) for ${agent}"
             fi
 
-            if ! out=$(npx -y skills add "$full_repo" "${name_args[@]}" -g --agent "$current_agent" -y < /dev/null 2>&1); then
+            if ! out=$(npx -y skills add "$full_repo" "${name_args[@]}" -g --agent "$agent" -y < /dev/null 2>&1); then
                 tui.error "Failed to install ${repo}"
                 echo "$out" | grep -v "█"
             fi
-        done < <(jq -r '.skills[]? | "\(.repo)\t\(.skills | join(",") // "")\t\(.agent // "")"' "$skills_file")
+        done < <(jq -r '.skills[]? | "\(.repo)\t\(.skills | join(",") // "")"' "$skills_file")
 
         tui.success "Configuration complete for $agent"
     } always {

--- a/src/zsh/functions/ai.zsh
+++ b/src/zsh/functions/ai.zsh
@@ -312,16 +312,17 @@ ai.skills.install() {
         while IFS=$'\t' read -r repo skills_str; do
             [[ -z "$repo" ]] && continue
 
-            # Handle relative local directories by prepending DOTFILES_DIR
+            # Handle relative local directories by prepending DOTFILES
             full_repo="$repo"
             if [[ "$repo" == ./* ]]; then
-                full_repo="${DOTFILES_DIR:-${HOME}/.dotfiles}/${repo#./}"
+                full_repo="${DOTFILES:-${HOME}/.dotfiles}/${repo#./}"
             fi
 
             name_args=()
             if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
                 tui.step "Skills: * (${repo}) for ${agent}"
             else
+                local name
                 for name in ${(s:,:)skills_str}; do
                     name_args+=(--skill "$name")
                 done

--- a/src/zsh/functions/ai.zsh
+++ b/src/zsh/functions/ai.zsh
@@ -306,13 +306,7 @@ ai.skills.install() {
         (( $+commands[jq] )) || { tui.warn "jq command not found, skipping"; return 0; }
         (( $+commands[npx] )) || { tui.warn "npx command not found, skipping"; return 0; }
 
-        tui.step "Linking skills directory"
-        local source_dir target_dir
-        source_dir=$(jq -r '.local.source // "ai/skills"' "$skills_file")
-        target_dir=$(eval echo "$(jq -r '.local.target // "~/.agents/skills"' "$skills_file")")
-        config.symlink --force --contents "$source_dir" "$target_dir"
-
-        local repo skills_str agent_config out
+        local repo skills_str agent_config out full_repo
         local -a name_args
 
         while IFS=$'\t' read -r repo skills_str agent_config; do
@@ -324,9 +318,14 @@ ai.skills.install() {
                  current_agent="$agent_config"
             fi
 
+            # Handle relative local directories by prepending DOTFILES_DIR
+            full_repo="$repo"
+            if [[ "$repo" == ./* ]]; then
+                full_repo="${DOTFILES_DIR:-${HOME}/.dotfiles}/${repo#./}"
+            fi
+
             name_args=()
             if [[ -z "$skills_str" || "$skills_str" == "*" ]]; then
-                name_args=(--skill "*")
                 tui.step "Skills: * (${repo}) for ${current_agent}"
             else
                 for name in ${(s:,:)skills_str}; do
@@ -335,11 +334,11 @@ ai.skills.install() {
                 tui.step "Skills: ${skills_str} (${repo}) for ${current_agent}"
             fi
 
-            if ! out=$(npx -y skills add "$repo" "${name_args[@]}" -g --agent "$current_agent" -y < /dev/null 2>&1); then
+            if ! out=$(npx -y skills add "$full_repo" "${name_args[@]}" -g --agent "$current_agent" -y < /dev/null 2>&1); then
                 tui.error "Failed to install ${repo}"
                 echo "$out" | grep -v "█"
             fi
-        done < <(jq -r '.remote[]? | "\(.repo)\t\(.skills | join(",") // "")\t\(.agent // "")"' "$skills_file")
+        done < <(jq -r '.skills[]? | "\(.repo)\t\(.skills | join(",") // "")\t\(.agent // "")"' "$skills_file")
 
         tui.success "Configuration complete for $agent"
     } always {


### PR DESCRIPTION
Moved the hardcoded skills out of `src/zsh/apps/pkg/recipes/ai/opencode.zsh` and placed them in a declarative `assets/configs/ai/skills.json` manifest file. Refactored the opencode zsh recipe to read from this JSON using `jq`. Fixes issue #16.

---
*PR created automatically by Jules for task [10798814028012274579](https://jules.google.com/task/10798814028012274579) started by @warpcode*