### PR TITLE
🧹 [code health] Remove commented-out block in 50-oh-my-zsh.zsh

### DIFF
--- a/src/zsh/config/50-oh-my-zsh.zsh
+++ b/src/zsh/config/50-oh-my-zsh.zsh
@@ -84,13 +84,6 @@ plugins=(
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8
 
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
-
 # Compilation flags
 # export ARCHFLAGS="-arch x86_64"
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out block of code related to setting the EDITOR variable.
💡 **Why:** Removing dead code improves the maintainability and readability of the codebase by reducing clutter.
✅ **Verification:** Verified by checking `git diff` that only the dead code was removed. There are no behavior changes since the code was commented out.
✨ **Result:** Improved code cleanliness and readability in `src/zsh/config/50-oh-my-zsh.zsh`.

---
*PR created automatically by Jules for task [11848715842121664740](https://jules.google.com/task/11848715842121664740) started by @warpcode*