### PR TITLE
🔒 fix: Command Injection via eval on Dynamic Input in env.zsh

### DIFF
--- a/src/zsh/functions/env.zsh
+++ b/src/zsh/functions/env.zsh
@@ -29,7 +29,7 @@ env.lazy.load() {
     deps=( ${=_ENV_LAZY_DEPS[$var]} )
     for dep in $deps; do
       if [[ -z ${seen[$dep]} ]]; then
-        eval "$dep" >/dev/null
+        env.lazy.load "$dep"
         seen[$dep]=1
       fi
     done


### PR DESCRIPTION
🎯 **What:** Command injection vulnerability in `env.lazy.load` via `eval "$dep"`.

⚠️ **Risk:** By manipulating the dependency string array during the lazy loading of environment variables, an attacker could potentially execute arbitrary commands as the dependency string was passed directly to `eval`. 

🛡️ **Solution:** Replaced `eval "$dep"` with `env.lazy.load "$dep"`. This ensures dependencies are safely loaded using the system's recursive capability instead of passing dynamically set variables into the shell eval logic.

---
*PR created automatically by Jules for task [5912034705077599726](https://jules.google.com/task/5912034705077599726) started by @warpcode*