### PR TITLE
🔒 Fix command injection risk in df.tui

### DIFF
--- a/bin/df.tui
+++ b/bin/df.tui
@@ -370,7 +370,7 @@ _preview() {
 
     local pcmd=${commands[pygmentize]:-$commands[pygmentise]}
     if [[ -n "$pcmd" ]]; then
-        $pcmd -f terminal -g "$file" 2>/dev/null | {
+        "$pcmd" -f terminal -g "$file" 2>/dev/null | {
             local i=0 content arrow="${(%):-%F{red}>>>%f}"
             while IFS= read -r content; do
                 (( ++i ))


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a command injection risk stemming from the implicit, unquoted command invocation of `$pcmd`.
⚠️ **Risk:** Without quotes, the resolved path to the command can be subjected to word splitting or globbing, potentially allowing arbitrary execution if a path containing spaces or malicious sequences is manipulated or misresolved.
🛡️ **Solution:** The fix wraps `$pcmd` in double quotes (`"$pcmd"`). This ensures that the shell evaluates the path as a single executable command regardless of spaces or special characters in the absolute path, preventing command injection.

---
*PR created automatically by Jules for task [65529702603445307](https://jules.google.com/task/65529702603445307) started by @warpcode*